### PR TITLE
add slash to socket.io url in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
     <script src="http://use.edgefonts.net/andika.js"></script>
     <script src="http://use.edgefonts.net/arvo.js"></script>
 
-	<script type="text/javascript" src="socket.io/socket.io.js"></script>
+	<script type="text/javascript" src="/socket.io/socket.io.js"></script>
     <script>
 // UNCOMMENT THIS CODE IF YOU USE THE "serverwithanalytics" SERVER
 //        var socket = io.connect();


### PR DESCRIPTION
added leading slash for socket.io.js url in `index.html` - without it browser gets 404 and in consequence Cloudify quickstart demo does not work correctly
